### PR TITLE
fix: KataGo setup loop when AppImageLauncher intercepts the engine

### DIFF
--- a/src/frank/katagoSetup.js
+++ b/src/frank/katagoSetup.js
@@ -12,10 +12,14 @@
 import {spawnSync} from 'child_process'
 import {
   chmodSync,
+  closeSync,
   createWriteStream,
   existsSync,
   mkdirSync,
+  openSync,
   readdirSync,
+  readSync,
+  rmSync,
   writeFileSync,
 } from 'fs'
 import {get} from 'https'
@@ -94,12 +98,60 @@ export function katagoBootsGtp(binary, config, model) {
         input: 'name\nquit\n',
         timeout: 60000,
         encoding: 'utf8',
+        // If the binary is still an AppImage (e.g. found on PATH), keep
+        // AppImageLauncher from hijacking the exec with a GUI dialog.
+        env: {...process.env, APPIMAGELAUNCHER_DISABLE: '1'},
       },
     )
     return result.status === 0
   } catch (err) {
     return false
   }
+}
+
+// KataGo's official Linux binaries are AppImages (type 2: magic bytes
+// "AI\x02" at offset 8). Run as-is they need FUSE, and AppImageLauncher —
+// common on Arch/CachyOS — intercepts the exec with an integration dialog
+// that *moves the file away*, breaking the engine and looping the setup.
+export function isAppImage(path) {
+  let fd
+  try {
+    fd = openSync(path, 'r')
+    let magic = Buffer.alloc(3)
+    let bytes = readSync(fd, magic, 0, 3, 8)
+    return (
+      bytes === 3 && magic[0] === 0x41 && magic[1] === 0x49 && magic[2] === 0x02
+    )
+  } catch (err) {
+    return false
+  } finally {
+    if (fd != null) closeSync(fd)
+  }
+}
+
+// Turns an AppImage katago into a plain binary by unpacking it once into
+// binDir/squashfs-root (`--appimage-extract` needs no FUSE) and returning
+// its AppRun. Plain binaries pass through untouched. `force` re-extracts,
+// e.g. when a fresh CPU build must replace a previously unpacked GPU one.
+export function extractAppImage(binary, binDir, {force = false} = {}) {
+  if (!isAppImage(binary)) return binary
+
+  let appRun = join(binDir, 'squashfs-root', 'AppRun')
+
+  if (force || !existsSync(appRun)) {
+    mkdirSync(binDir, {recursive: true})
+    rmSync(join(binDir, 'squashfs-root'), {recursive: true, force: true})
+
+    let result = spawnSync(binary, ['--appimage-extract'], {
+      cwd: binDir,
+      stdio: 'pipe',
+      env: {...process.env, APPIMAGELAUNCHER_DISABLE: '1'},
+    })
+
+    if (result.status !== 0 || !existsSync(appRun)) return binary
+  }
+
+  return appRun
 }
 
 export function findKatagoOnPath() {
@@ -130,17 +182,20 @@ export async function ensureKatagoBinary({
   forceDownload = false,
   onProgress = () => {},
 }) {
-  if (!forceDownload) {
-    let onPath = findKatagoOnPath()
-    if (onPath != null) return onPath
-  }
-
   let binDir = join(dir, 'bin')
   let localBinary = join(
     binDir,
     process.platform === 'win32' ? 'katago.exe' : 'katago',
   )
-  if (existsSync(localBinary)) return localBinary
+  let extracted = join(binDir, 'squashfs-root', 'AppRun')
+
+  if (!forceDownload) {
+    let onPath = findKatagoOnPath()
+    if (onPath != null) return extractAppImage(onPath, binDir)
+
+    if (existsSync(extracted)) return extracted
+    if (existsSync(localBinary)) return extractAppImage(localBinary, binDir)
+  }
 
   if (process.platform === 'darwin') {
     throw new Error(
@@ -178,7 +233,7 @@ export async function ensureKatagoBinary({
   }
 
   if (process.platform !== 'win32') chmodSync(binary, 0o755)
-  return binary
+  return extractAppImage(binary, binDir, {force: true})
 }
 
 export async function ensureNetwork(key, {dir, onProgress = () => {}}) {

--- a/test/frank/katagoSetupTests.js
+++ b/test/frank/katagoSetupTests.js
@@ -1,10 +1,18 @@
 import assert from 'assert'
-import {existsSync, mkdtempSync, readFileSync} from 'fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs'
 import {tmpdir} from 'os'
 import {join} from 'path'
 import {
   HUMAN_RANKS,
   buildEngineEntries,
+  extractAppImage,
+  isAppImage,
   mergeEngines,
   writeConfigs,
 } from '../../src/frank/katagoSetup.js'
@@ -71,6 +79,60 @@ describe('buildEngineEntries', () => {
     assert.ok(
       humanEngines.every((engine) => engine.args.includes('-human-model')),
     )
+  })
+})
+
+describe('isAppImage', () => {
+  it('detects the type-2 magic bytes at offset 8', () => {
+    let dir = mkdtempSync(join(tmpdir(), 'frank-kata-'))
+    let path = join(dir, 'katago')
+
+    writeFileSync(
+      path,
+      // 8 bytes of ELF-ish header, then the AppImage magic at offset 8
+      Buffer.concat([
+        Buffer.from('\x7fELF\x02\x01\x01\x00', 'latin1'),
+        Buffer.from('AI\x02rest', 'latin1'),
+      ]),
+    )
+    assert.ok(isAppImage(path))
+  })
+
+  it('rejects plain binaries and missing files', () => {
+    let dir = mkdtempSync(join(tmpdir(), 'frank-kata-'))
+    let plain = join(dir, 'plain')
+
+    writeFileSync(plain, 'just a regular executable, nothing to see')
+    assert.ok(!isAppImage(plain))
+    assert.ok(!isAppImage(join(dir, 'does-not-exist')))
+  })
+})
+
+describe('extractAppImage', () => {
+  it('passes plain binaries through untouched', () => {
+    let dir = mkdtempSync(join(tmpdir(), 'frank-kata-'))
+    let plain = join(dir, 'katago')
+
+    writeFileSync(plain, '\x7fELF plain binary')
+    assert.equal(extractAppImage(plain, dir), plain)
+  })
+
+  it('returns a previously extracted AppRun without re-running', () => {
+    let dir = mkdtempSync(join(tmpdir(), 'frank-kata-'))
+    let appImage = join(dir, 'katago')
+    let appRun = join(dir, 'squashfs-root', 'AppRun')
+
+    writeFileSync(
+      appImage,
+      Buffer.concat([
+        Buffer.from('\x7fELF\x02\x01\x01\x00', 'latin1'),
+        Buffer.from('AI\x02', 'latin1'),
+      ]),
+    )
+    mkdirSync(join(dir, 'squashfs-root'), {recursive: true})
+    writeFileSync(appRun, '#!/bin/sh\n')
+
+    assert.equal(extractAppImage(appImage, dir), appRun)
   })
 })
 


### PR DESCRIPTION
## The bug

On systems with **AppImageLauncher** installed (very common on Arch/CachyOS — frank_go's own AUR audience), the one-click KataGo setup gets stuck in an infinite loop:

1. "Install CPU engine" downloads the official KataGo release and extracts `bin/katago` — which, since v1.16, is a **type-2 AppImage**, not a plain binary.
2. The first time the app (or the boot check) executes it, AppImageLauncher intercepts the exec and pops its integration dialog.
3. If the user integrates, AppImageLauncher **moves the binary** to `~/Applications/katago_<md5>` — it vanishes from `frank-katago/bin/`.
4. The engine can't start, the play pre-flight fails, and the app shows "KataGo could not start … Install a CPU engine now?" again. Repeat forever.

Verified on CachyOS: magic bytes `AI\x02` at offset 8 of the downloaded `katago`, and the moved file sitting in `~/Applications`.

## The fix

All in `src/frank/katagoSetup.js`, keeping the module env-agnostic:

- `isAppImage()` — detects the type-2 magic bytes.
- `extractAppImage()` — unpacks the AppImage once via `--appimage-extract` (needs no FUSE; runs with `APPIMAGELAUNCHER_DISABLE=1` so it can't be hijacked) and returns the plain `squashfs-root/AppRun`. Plain binaries pass through untouched.
- `ensureKatagoBinary()` — every resolution path (PATH hit, cached download, fresh download) goes through the extraction; forced re-downloads re-extract so a previously unpacked broken GPU build is never reused.
- `katagoBootsGtp()` — spawns with `APPIMAGELAUNCHER_DISABLE=1` so the boot check never triggers the integration dialog either.

Side benefit: the engine no longer needs FUSE at play time.

Existing installs self-heal: the next click on "Install CPU engine" re-registers the engines pointing at the extracted binary.

## Testing

- 4 new unit tests (`isAppImage` detection/rejection, `extractAppImage` passthrough and cache); full suite: 172 passing.
- End-to-end on CachyOS with AppImageLauncher active: fresh setup detects the AppImage, extracts silently (no dialog), GTP boots with the fast network, and play-vs-KataGo works in the app.

(Happy to add a CHANGELOG entry if you prefer it in the PR — left it out assuming the changelog is managed at release time.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUH94huNVQ364p1JWoTpkp