### PR TITLE
fix(tsumego): success banner shouldn't credit KataGo when a solution tree resolved it

### DIFF
--- a/src/frank/tsumegoSession.js
+++ b/src/frank/tsumegoSession.js
@@ -214,6 +214,11 @@ function opponentName() {
 }
 
 function successText() {
+  // A solution-tree win isn't the engine giving up on anything — it's a
+  // verified correct line (its own comment already explains the "why").
+  // The KataGo-flavored phrasing below only fits the sparring path.
+  if (checker != null) return t('Solved!')
+
   return goal === 'live'
     ? t('KataGo gave up the attack — your group lives. Solved!')
     : t('KataGo left the fight — {{opponent}} is dead. Solved!').replace(


### PR DESCRIPTION
Problems with a real solution tree (`hasSolutions`/`sgf`, today only the GoGameGuru set) are graded by walking that tree exactly — no engine involved, `unassignSparringColors()` even turns KataGo off for the duration. But `successText()` always rendered "KataGo left the fight — X is dead. Solved!" regardless of which grading path actually resolved the problem.

This already happens today any time a GGG problem is drawn in the normal level-based practice (GGG problems already carry `hasSolutions`/`sgf` directly in `data/tsumego/index.json`, so the tree path already runs for them) — the banner just took credit for something the engine didn't do.

`successText()` now checks `checker != null` first and shows a plain "Solved!" when a verified tree line resolved it, keeping the KataGo-flavored text for the actual sparring/heuristic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H63B17YCTf1xokQy8RkvSM
