### PR TITLE
feat(tsumego): sequential study mode for GoGameGuru's solution-backed problems

### DIFF
--- a/src/components/frank/PracticeSidebar.js
+++ b/src/components/frank/PracticeSidebar.js
@@ -184,6 +184,8 @@ export default class PracticeSidebar extends Component {
 
     this.handleStartTsumego = () => tsumegoSession.startPractice()
 
+    this.handleStartGGGStudy = () => tsumegoSession.startSolvedStudy()
+
     this.handlePlayBlack = () => katagoPlay.playAgainstKataGo(1)
 
     this.handlePlayWhite = () => katagoPlay.playAgainstKataGo(-1)
@@ -643,9 +645,12 @@ export default class PracticeSidebar extends Component {
       focus,
       autoVerdict,
       lastEvent,
+      mode,
+      sequencePosition,
     } = tsumego
     let toPlayLabel =
       problem.toPlay === 'W' ? t('White to play') : t('Black to play')
+    let sequential = mode === 'sequential'
 
     let streakDots = [...Array(streakTarget)].map((_, i) =>
       h('span', {
@@ -660,7 +665,14 @@ export default class PracticeSidebar extends Component {
       h(
         'div',
         {class: 'header'},
-        h('span', {class: 'title'}, '🧩 ', t('Tsumego Practice')),
+        h(
+          'span',
+          {class: 'title'},
+          sequential ? '📖 ' : '🧩 ',
+          sequential
+            ? t('Tsumego — solved & commented')
+            : t('Tsumego Practice'),
+        ),
         h(
           'a',
           {href: '#', class: 'stop', onClick: this.handleStopTsumego},
@@ -668,73 +680,98 @@ export default class PracticeSidebar extends Component {
         ),
       ),
 
-      h(
-        'div',
-        {class: 'levelrow'},
-        h(
-          'span',
-          {class: 'stepper'},
-          h(
-            'button',
-            {
-              class: 'levelstep',
-              title: t('Easier problems'),
-              disabled: progress.level <= 1,
-              onClick: this.handleLevelDown,
-            },
-            '−',
+      sequential
+        ? h(
+            'div',
+            {class: 'levelrow'},
+            h(
+              'span',
+              {class: 'level'},
+              t('Problem'),
+              ' ',
+              sequencePosition.current,
+              ' ',
+              t('of'),
+              ' ',
+              sequencePosition.total,
+            ),
+          )
+        : h(
+            'div',
+            {class: 'levelrow'},
+            h(
+              'span',
+              {class: 'stepper'},
+              h(
+                'button',
+                {
+                  class: 'levelstep',
+                  title: t('Easier problems'),
+                  disabled: progress.level <= 1,
+                  onClick: this.handleLevelDown,
+                },
+                '−',
+              ),
+              h(
+                'span',
+                {class: 'level', title: t('Choose your difficulty')},
+                t('Level'),
+                ' ',
+                progress.level,
+              ),
+              h(
+                'button',
+                {
+                  class: 'levelstep',
+                  title: t('Harder problems'),
+                  disabled: progress.level >= 10,
+                  onClick: this.handleLevelUp,
+                },
+                '+',
+              ),
+            ),
+            h(
+              'span',
+              {class: 'dots', title: t('Solve 5 in a row to level up')},
+              streakDots,
+            ),
           ),
-          h(
-            'span',
-            {class: 'level', title: t('Choose your difficulty')},
-            t('Level'),
-            ' ',
-            progress.level,
-          ),
-          h(
-            'button',
-            {
-              class: 'levelstep',
-              title: t('Harder problems'),
-              disabled: progress.level >= 10,
-              onClick: this.handleLevelUp,
-            },
-            '+',
-          ),
-        ),
-        h(
-          'span',
-          {class: 'dots', title: t('Solve 5 in a row to level up')},
-          streakDots,
-        ),
-      ),
 
-      h(
-        'p',
-        {class: 'ranknote'},
-        `${LEVEL_RANKS[progress.level]} · ${t('solve 5 in a row to level up')}`,
-        lastEvent != null &&
-          h(
-            'span',
-            {class: classNames('event', lastEvent)},
-            ' ',
-            lastEvent === 'level-up' ? t('Level up!') : t('Level down'),
-          ),
-      ),
-
-      h(
-        'label',
-        {class: 'strength focusrow'},
-        t('Focus:'),
-        ' ',
+      sequential &&
         h(
-          'select',
-          {value: focus, onChange: this.handleFocusChoice},
-          Object.entries(FOCUS_LABELS).map(([value, label]) =>
-            h('option', {value}, t(label)),
+          'p',
+          {class: 'ranknote'},
+          `${sequencePosition.solved} ${t('of')} ${sequencePosition.total} ${t('solved so far')}`,
+        ),
+
+      !sequential &&
+        h(
+          'p',
+          {class: 'ranknote'},
+          `${LEVEL_RANKS[progress.level]} · ${t('solve 5 in a row to level up')}`,
+          lastEvent != null &&
+            h(
+              'span',
+              {class: classNames('event', lastEvent)},
+              ' ',
+              lastEvent === 'level-up' ? t('Level up!') : t('Level down'),
+            ),
+        ),
+
+      !sequential &&
+        h(
+          'label',
+          {class: 'strength focusrow'},
+          t('Focus:'),
+          ' ',
+          h(
+            'select',
+            {value: focus, onChange: this.handleFocusChoice},
+            Object.entries(FOCUS_LABELS).map(([value, label]) =>
+              h('option', {value}, t(label)),
+            ),
           ),
         ),
-      ),
 
       h(
         'div',
@@ -1442,6 +1479,11 @@ export default class PracticeSidebar extends Component {
           'button',
           {class: 'primary', onClick: this.handleStartTsumego},
           `🧩 ${t('Tsumego practice')} · ${t('Level')} ${level} (${LEVEL_RANKS[level]})`,
+        ),
+        h(
+          'button',
+          {onClick: this.handleStartGGGStudy},
+          `📖 ${t('Tsumego — solved & commented')}`,
         ),
       ),
 

--- a/src/frank/data/problemStore.js
+++ b/src/frank/data/problemStore.js
@@ -118,6 +118,46 @@ export class ProblemStore {
   }
 }
 
+// Flattens the three GoGameGuru collections into one ordered sequence
+// (easy → intermediate → hard, each internally sorted by problem number)
+// for sequential, solution-backed study — no random draw, no level/streak.
+export function buildGGGSequence(store) {
+  return [
+    ...store.query({collection: 'ggg-easy'}),
+    ...store.query({collection: 'ggg-intermediate'}),
+    ...store.query({collection: 'ggg-hard'}),
+  ]
+}
+
+// Index of the first problem in the sequence not in `solvedIds`, in
+// strict order from the start — the natural "resume where I still have
+// work" point when reopening the mode. Falls back to 0 (free review from
+// the top) once everything is solved.
+export function firstUnsolvedIndex(sequence, solvedIds) {
+  let index = sequence.findIndex((problem) => !solvedIds.has(problem.id))
+  return index === -1 ? 0 : index
+}
+
+// Returns the index of the next problem after `from` that isn't in
+// `solvedIds`, walking forward in strict numeric order and wrapping at
+// most once — so repeat sessions naturally land only on what's left,
+// without reshuffling or a separate "review" mode. Falls back to the
+// plain next-in-order index if every remaining problem is already solved
+// (nothing left to skip to).
+export function nextUnsolvedIndex(sequence, from, solvedIds) {
+  if (sequence.length === 0) return 0
+
+  let fallback = (from + 1) % sequence.length
+  let next = fallback
+
+  for (let steps = 0; steps < sequence.length; steps++) {
+    if (!solvedIds.has(sequence[next].id)) return next
+    next = (next + 1) % sequence.length
+  }
+
+  return fallback
+}
+
 // Renders a problem as a standalone SGF so it can be loaded through
 // Sabaki's regular file loading pipeline.
 export function problemToSgf(problem) {

--- a/src/frank/tsumegoSession.js
+++ b/src/frank/tsumegoSession.js
@@ -20,7 +20,14 @@ import sgf from '@sabaki/sgf'
 import * as gametree from '../modules/gametree.js'
 import * as dialog from '../modules/dialog.js'
 import i18n from '../i18n.js'
-import {getSharedStore, problemToSgf, createRng} from './data/problemStore.js'
+import {
+  getSharedStore,
+  problemToSgf,
+  createRng,
+  buildGGGSequence,
+  nextUnsolvedIndex,
+  firstUnsolvedIndex,
+} from './data/problemStore.js'
 import {
   STREAK_TO_LEVEL_UP,
   applyResult,
@@ -52,6 +59,12 @@ let currentProblem = null
 let sessionStats = {solved: 0, missed: 0}
 let sparringSyncerId = null
 
+// 'level': the usual level/streak practice, random draw. 'sequential':
+// study mode — walks every GoGameGuru problem in order, no level/streak,
+// because those come with a real, comment-backed solution tree.
+let mode = 'level'
+let cachedGGGSequence = null
+
 // Per-problem auto-grading state
 let goal = null // 'kill' | 'live'
 let settled = false
@@ -73,6 +86,35 @@ function loadSolvedIds() {
 function saveSolvedIds(solvedIds) {
   let ids = [...solvedIds].slice(-MAX_SOLVED_REMEMBERED)
   setting.set('frank.tsumego_solved', JSON.stringify({ids}))
+}
+
+// Static bundled data — build the 420-problem walk order once.
+function gggSequence() {
+  if (cachedGGGSequence == null) {
+    cachedGGGSequence = buildGGGSequence(getSharedStore())
+  }
+  return cachedGGGSequence
+}
+
+// How many of the 420 GGG problems have ever been solved (persisted
+// alongside the level-mode's own solved set — the cursor only tracks
+// *position*, this is the actual progress count).
+function countGGGSolved() {
+  let solvedIds = loadSolvedIds()
+  return gggSequence().filter((problem) => solvedIds.has(problem.id)).length
+}
+
+// Always returns a valid index into the sequence, even if the stored
+// cursor is stale (e.g. the bundled GGG count changed between versions)
+// or missing — so the position display and problem lookup never disagree.
+function loadGGGCursor() {
+  let raw = Math.max(0, setting.get('frank.tsumego_ggg_cursor') || 0)
+  let length = gggSequence().length
+  return length === 0 ? 0 : raw % length
+}
+
+function saveGGGCursor(cursor) {
+  setting.set('frank.tsumego_ggg_cursor', cursor)
 }
 
 function publishState(progress, lastEvent = null) {
@@ -107,6 +149,15 @@ function publishState(progress, lastEvent = null) {
                 : null,
             autoVerdict,
             lastEvent,
+            mode,
+            sequencePosition:
+              mode === 'sequential'
+                ? {
+                    current: loadGGGCursor() + 1,
+                    total: gggSequence().length,
+                    solved: countGGGSolved(),
+                  }
+                : null,
           },
   })
 }
@@ -238,6 +289,12 @@ function scheduleAutoSolve() {
   publishState(loadProgress())
 
   cancelAutoAdvance()
+
+  // Sequential study mode is about reading the comment (often what makes
+  // the move correct in the first place) — auto-advancing after a couple
+  // seconds cuts that off. Wait for an explicit "Next problem" instead.
+  if (mode === 'sequential') return
+
   autoAdvanceTimer = setTimeout(() => {
     autoAdvanceTimer = null
     answer(true)
@@ -267,12 +324,30 @@ async function failAndPrompt(text) {
 
   if (choice === 0) {
     await retryProblem()
+  } else if (mode === 'sequential') {
+    await advanceSequential()
   } else {
     await advanceToNextProblem()
   }
 }
 
 // Advances without grading (the miss/solve has already been recorded).
+// Sequential mode's equivalent of advanceToNextProblem: moves forward in
+// the 420-long GGG walk order (still strict numeric order, still wraps),
+// skipping anything already solved — so repeat sessions naturally land
+// only on what's left, without a separate "review" mode.
+async function advanceSequential() {
+  let sequence = gggSequence()
+  if (sequence.length === 0) return
+
+  let cursor = nextUnsolvedIndex(sequence, loadGGGCursor(), loadSolvedIds())
+  saveGGGCursor(cursor)
+
+  currentProblem = sequence[cursor]
+  await loadProblemIntoBoard(currentProblem)
+  publishState(loadProgress())
+}
+
 async function advanceToNextProblem() {
   let progress = loadProgress()
   let problem = pickProblem(getSharedStore(), {
@@ -533,6 +608,7 @@ export async function startPractice() {
   if (problem == null) return
 
   sessionStats = {solved: 0, missed: 0}
+  mode = 'level'
   ensureSparringPartner()
   attachMoveListener()
 
@@ -541,6 +617,36 @@ export async function startPractice() {
   currentProblem = problem
   await loadProblemIntoBoard(problem, {firstLoad: true})
   publishState(progress)
+}
+
+// Study mode: walks every GoGameGuru problem in order (easy → intermediate
+// → hard), a real comment-backed solution tree instead of a heuristic
+// guess — no level, no streak, just working through all 420 at your pace.
+export async function startSolvedStudy() {
+  await stopOtherActivities()
+
+  let sequence = gggSequence()
+  if (sequence.length === 0) return
+
+  // Reopening from the menu always resumes at the first problem you still
+  // haven't solved — so an accidental skip is recovered just by going back
+  // and reopening, instead of having to walk all the way around. The
+  // cursor still advances normally with "Next" once you're in.
+  let cursor = firstUnsolvedIndex(sequence, loadSolvedIds())
+  saveGGGCursor(cursor)
+
+  let problem = sequence[cursor]
+
+  sessionStats = {solved: 0, missed: 0}
+  mode = 'sequential'
+  ensureSparringPartner()
+  attachMoveListener()
+
+  hideGtpConsole(sabaki)
+
+  currentProblem = problem
+  await loadProblemIntoBoard(problem, {firstLoad: true})
+  publishState(loadProgress())
 }
 
 // Manual grading — used by the auto-solve timer, the "Next" button on a
@@ -562,18 +668,44 @@ export async function answer(correct) {
   if (currentProblem == null) return
 
   cancelAutoAdvance()
+  sessionStats[correct ? 'solved' : 'missed']++
+
+  // Detect the moment a *newly* solved problem completes the whole GGG
+  // set — only true on the transition to 420/420, not on later reviews.
+  let justCompletedAll = false
+
+  if (correct) {
+    let solvedIds = loadSolvedIds()
+    let wasAlreadySolved = solvedIds.has(currentProblem.id)
+    solvedIds.add(currentProblem.id)
+    saveSolvedIds(solvedIds)
+
+    justCompletedAll =
+      mode === 'sequential' &&
+      !wasAlreadySolved &&
+      countGGGSolved() === gggSequence().length
+  }
+
+  if (mode === 'sequential') {
+    await advanceSequential()
+
+    if (justCompletedAll) {
+      await dialog.showMessageBox(
+        t(
+          '🎉 Congratulations! You’ve worked through all 420 GoGameGuru problems. From here it’s free review — every problem is still here to revisit.',
+        ),
+        'info',
+        [t('Nice!')],
+      )
+    }
+
+    return
+  }
 
   let progress = loadProgress()
   let next = applyResult(progress, correct)
   saveProgress(next)
   flashLevelEvent(next)
-  sessionStats[correct ? 'solved' : 'missed']++
-
-  if (correct) {
-    let solvedIds = loadSolvedIds()
-    solvedIds.add(currentProblem.id)
-    saveSolvedIds(solvedIds)
-  }
 
   let problem = pickProblem(getSharedStore(), {
     level: next.level,
@@ -611,7 +743,7 @@ export const LEVEL_RANKS = {
 // Lets the player choose their own difficulty; loads a fresh problem at
 // the new level without grading the current one.
 export async function setLevel(level) {
-  if (currentProblem == null) return
+  if (currentProblem == null || mode === 'sequential') return
 
   level = Math.min(10, Math.max(1, Math.round(level)))
   cancelAutoAdvance()
@@ -625,6 +757,12 @@ export async function skipProblem() {
   if (currentProblem == null) return
 
   cancelAutoAdvance()
+
+  if (mode === 'sequential') {
+    await advanceSequential()
+    return
+  }
+
   await advanceToNextProblem()
 }
 
@@ -653,6 +791,7 @@ export function stopPractice() {
   cancelAutoAdvance()
   detachMoveListener()
   currentProblem = null
+  mode = 'level'
 
   if (sparringSyncerId != null) {
     sabaki.detachEngines([sparringSyncerId])

--- a/test/frank/problemStoreTests.js
+++ b/test/frank/problemStoreTests.js
@@ -3,6 +3,9 @@ import {
   ProblemStore,
   createRng,
   problemToSgf,
+  buildGGGSequence,
+  nextUnsolvedIndex,
+  firstUnsolvedIndex,
 } from '../../src/frank/data/problemStore.js'
 
 function makeIndex() {
@@ -145,6 +148,131 @@ describe('ProblemStore', () => {
       total: 4,
       byLevel: {1: 1, 2: 1, 8: 1, 9: 1},
     })
+  })
+})
+
+describe('buildGGGSequence', () => {
+  function makeGGGIndex() {
+    let stub = (id, collection, n) => ({
+      id,
+      collection,
+      n,
+      title: `problem ${n}`,
+      level: 5,
+      category: 'life-and-death',
+      toPlay: 'B',
+      size: 19,
+      AB: ['aa'],
+      AW: ['ab'],
+      region: [0, 0, 0, 0],
+    })
+
+    return {
+      version: 1,
+      collections: {},
+      // Interleaved on purpose (not already grouped by collection) so the
+      // test can't pass by accident — buildGGGSequence must do the
+      // grouping itself, not just pass the array through.
+      problems: [
+        stub('ggg-hard/1', 'ggg-hard', 1),
+        stub('cho-elementary/1', 'cho-elementary', 1), // must be excluded
+        stub('ggg-easy/1', 'ggg-easy', 1),
+        stub('ggg-intermediate/1', 'ggg-intermediate', 1),
+        stub('ggg-hard/2', 'ggg-hard', 2),
+        stub('ggg-easy/2', 'ggg-easy', 2),
+        stub('ggg-intermediate/2', 'ggg-intermediate', 2),
+      ],
+    }
+  }
+
+  it('orders easy → intermediate → hard and excludes other collections', () => {
+    let store = new ProblemStore(makeGGGIndex())
+
+    assert.deepEqual(
+      buildGGGSequence(store).map((p) => p.id),
+      [
+        'ggg-easy/1',
+        'ggg-easy/2',
+        'ggg-intermediate/1',
+        'ggg-intermediate/2',
+        'ggg-hard/1',
+        'ggg-hard/2',
+      ],
+    )
+  })
+
+  it('covers all 420 bundled GGG problems, grouped and numbered in order', () => {
+    let store = ProblemStore.fromFile()
+    let sequence = buildGGGSequence(store)
+
+    assert.equal(sequence.length, 420)
+    assert.deepEqual(
+      sequence.slice(0, 140).map((p) => p.collection),
+      Array(140).fill('ggg-easy'),
+    )
+    assert.deepEqual(
+      sequence.slice(140, 280).map((p) => p.collection),
+      Array(140).fill('ggg-intermediate'),
+    )
+    assert.deepEqual(
+      sequence.slice(280, 420).map((p) => p.collection),
+      Array(140).fill('ggg-hard'),
+    )
+    assert.deepEqual(
+      sequence.slice(0, 140).map((p) => p.n),
+      Array.from({length: 140}, (_, i) => i + 1),
+    )
+  })
+})
+
+describe('nextUnsolvedIndex', () => {
+  let sequence = [{id: 'a'}, {id: 'b'}, {id: 'c'}, {id: 'd'}, {id: 'e'}]
+
+  it('returns the very next index when it is unsolved', () => {
+    assert.equal(nextUnsolvedIndex(sequence, 0, new Set()), 1)
+  })
+
+  it('skips over solved problems, landing on the first unsolved one', () => {
+    let solved = new Set(['b', 'c', 'd'])
+    assert.equal(nextUnsolvedIndex(sequence, 0, solved), 4) // 'e'
+  })
+
+  it('wraps around past the end back to the beginning', () => {
+    let solved = new Set(['e', 'a'])
+    assert.equal(nextUnsolvedIndex(sequence, 3, solved), 1) // skips e, a → b
+  })
+
+  it('falls back to the plain next-in-order index when everything is solved', () => {
+    let solved = new Set(['a', 'b', 'c', 'd', 'e'])
+    assert.equal(nextUnsolvedIndex(sequence, 1, solved), 2)
+  })
+
+  it('returns 0 for an empty sequence', () => {
+    assert.equal(nextUnsolvedIndex([], 0, new Set()), 0)
+  })
+})
+
+describe('firstUnsolvedIndex', () => {
+  let sequence = [{id: 'a'}, {id: 'b'}, {id: 'c'}, {id: 'd'}, {id: 'e'}]
+
+  it('returns 0 when nothing is solved yet', () => {
+    assert.equal(firstUnsolvedIndex(sequence, new Set()), 0)
+  })
+
+  it('skips leading solved problems to the first unsolved one', () => {
+    assert.equal(firstUnsolvedIndex(sequence, new Set(['a', 'b'])), 2)
+  })
+
+  it('finds an unsolved gap even after later problems were solved', () => {
+    // 'c' was skipped by mistake; 'd'/'e' solved later — resume lands on 'c'.
+    assert.equal(firstUnsolvedIndex(sequence, new Set(['a', 'b', 'd', 'e'])), 2)
+  })
+
+  it('falls back to 0 (free review) once everything is solved', () => {
+    assert.equal(
+      firstUnsolvedIndex(sequence, new Set(['a', 'b', 'c', 'd', 'e'])),
+      0,
+    )
   })
 })
 


### PR DESCRIPTION
Solving tsumego alone — no stronger player around to check your reading — only really works if the answer is trustworthy. The 420 GoGameGuru problems (`data/tsumego/ggg/`) are the only ones in frank_go with a real, human-curated solution tree (`hasSolutions`, licensed CC BY-NC-SA 4.0). Everything else ships without solutions on purpose (see `SOURCES.md`), graded live by KataGo's Monte-Carlo dead-stone heuristic instead.

That heuristic path is a reasonable way to play *against* an engine, but isn't necessarily a good way to *verify an answer*: `settleAndJudge` judges the local fight as soon as the opponent tenukis or passes, without requiring the fight to actually finish on the board. A genuinely correct sequence can register as unsolved for reasons that have nothing to do with the player's reading. This PR doesn't fix that — it's a separate, larger change to how the sparring engine plays out a local fight — but it does make the one grading path that's already trustworthy (GGG's real solution tree) actually reachable, since today it only surfaces through a same-level random-draw tiebreak, and GGG covers levels 2–9 only (a level-1 player, the default, sees zero GGG problems until leveling up through that same heuristic).

## What it adds

A new, separate practice mode ("📖 Tsumego — solved & commented", alongside the existing "🧩 Tsumego practice" button) that walks all 420 GGG problems in strict numeric order (easy → intermediate → hard), independent of level/streak:

- **`buildGGGSequence()`** (`data/problemStore.js`): pure, flattens the three GGG collections in collection order.
- **`startSolvedStudy()` / `advanceSequential()`** (`tsumegoSession.js`): mirrors `startPractice()`/`pickProblem()` but walks the sequence by a persisted cursor (`frank.tsumego_ggg_cursor`) instead of level+random draw.
- **Grading is unchanged** — GGG problems already carry `hasSolutions`/`sgf`, so `loadProblemIntoBoard`'s existing `createChecker` path handles them exactly as it always has. This is purely a different way to pick the next problem. `tsumegoProgress.js`/`pickProblem` is untouched; GGG problems still appear in the normal level-based draw too.
- **Skips already-solved problems**, both when advancing (`nextUnsolvedIndex`) and when reopening the mode from the menu (`firstUnsolvedIndex`): "Next" moves to the next unsolved one, and reopening resumes at the first unsolved one — so an accidental skip (or a wrong answer followed by "Next problem") is recovered just by going back to the menu and reopening, without a separate "review" mode. Both are pure and tested; both fall back gracefully once everything is solved. The sidebar shows "N of 420 solved so far" (`countGGGSolved()`, cross-referencing the already-persisted solved-ids set — no new setting needed, that data was already being saved, it just wasn't being read back).
- **Solving the last remaining problem** shows a one-time "all 420 done" congratulations (only on the transition to 420/420, not on later reviews); from there the mode is free review.

Also fixes `scheduleAutoSolve()`, which always auto-advanced 2.6s after a correct answer — fine for quick drilling, but in this study mode it cut off the winning move's comment (often the whole point of the exercise) before it could be read. Sequential mode now waits for an explicit "Next problem" click.

## Tests

`npm test` — 186 passing, including new cases for `buildGGGSequence`, `nextUnsolvedIndex`, and `firstUnsolvedIndex` (ordering, skipping, wrap-around, and the all-solved fallbacks). Manually verified in-app: the mode advances sequentially, skips solved problems, resumes at the first unsolved one on reopen, and shows the progress count.

## Note

Independent of #8 (the success-banner fix) — this branch doesn't include it, so until #8 lands the GGG mode shows the old "KataGo left the fight…" banner text on a solved problem. Purely cosmetic; the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H63B17YCTf1xokQy8RkvSM
